### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,9 +25,6 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "dependencies": {
-    "react-native-svg": "^9.3.3"
-  },
   "author": "",
   "license": "ISC"
 }


### PR DESCRIPTION
remove dependency react-native-svg and just mention it is required in the installation guide.

to avoid conflicts with other libraries using the same causing this issue: 

“Tried to register two views with the same name RNSVGRect”